### PR TITLE
Fixed automated email and picture upload bugs

### DIFF
--- a/mits/automated_emails.py
+++ b/mits/automated_emails.py
@@ -14,7 +14,7 @@ AutomatedEmail.queries[MITSTeam] = lambda session: session.mits_teams()
 # currently completion percentage when that info will probably be out of date
 # by the time they read it.  By waiting an hour, we ensure this doesn't happen.
 MITSEmail('Thanks for showing an interest in MITS!', 'mits_registered.txt',
-          lambda team: not team.submitted and team.registered < datetime.now(UTC) - timedelta(hours=1),
+          lambda team: not team.submitted and team.applied < datetime.now(UTC) - timedelta(hours=1),
           ident='mits_application_created')
 
 # For similar reasons to the above, we wait at least 6 hours before sending this
@@ -23,7 +23,7 @@ MITSEmail('Thanks for showing an interest in MITS!', 'mits_registered.txt',
 # until they've had a chance to complete the application and even receive the
 # initial reminder email above before being pestered with this warning.
 MITSEmail('Last chance to complete your MITS application!', 'mits_reminder.txt',
-          lambda team: not team.submitted and team.registered < datetime.now(UTC) - timedelta(hours=6),
+          lambda team: not team.submitted and team.applied < datetime.now(UTC) - timedelta(hours=6),
           when=days_before(3, c.MITS_SUBMISSION_DEADLINE),
           ident='mits_reminder')
 

--- a/mits/site_sections/mits_applications.py
+++ b/mits/site_sections/mits_applications.py
@@ -90,6 +90,8 @@ class Root:
             picture.content_type = image.content_type.value
             picture.extension = image.filename.split('.')[-1].lower()
             message = check(picture)
+            if not message and not image.file:
+                message = 'You must select a picture to upload'
             if not message:
                 with open(picture.filepath, 'wb') as f:
                     shutil.copyfileobj(image.file, f)


### PR DESCRIPTION
Two minor fixes thanks to Janus testing out the system:

1) There was a typo in the automated email lambdas that checked for ``team.registered`` instead of ``team.applied``, so I've fixed that.  The other email already worked, which happened to be the one that I'd tested looking at on the pending emails page - derp.

2) Janus also noticed that if you submitted the picture upload form without actually selecting a picture then instead of getting a nice error message, you'd get a confusing stacktrace.  I've added a check so that you get a clear error message telling you to select a picture to be uploaded.