### PR TITLE
A very MITS thanksgiving

### DIFF
--- a/alembic/versions/735063d71b57_added_document_uploads_and_team_deletion.py
+++ b/alembic/versions/735063d71b57_added_document_uploads_and_team_deletion.py
@@ -46,8 +46,14 @@ def upgrade():
     sa.ForeignKeyConstraint(['team_id'], ['mits_team.id'], name=op.f('fk_mits_document_team_id_mits_team')),
     sa.PrimaryKeyConstraint('id', name=op.f('pk_mits_document'))
     )
-    op.add_column('mits_team', sa.Column('deleted', sa.Boolean(), server_default='False', nullable=False))
-    op.add_column('mits_team', sa.Column('duplicate_of', sideboard.lib.sa.UUID(), nullable=True))
+
+    if is_sqlite:
+        with op.batch_alter_table('mits_team', reflect_kwargs=sqlite_reflect_kwargs) as batch_op:
+            batch_op.add_column(sa.Column('deleted', sa.Boolean(), server_default='False', nullable=False))
+            batch_op.add_column(sa.Column('duplicate_of', sideboard.lib.sa.UUID(), nullable=True))
+    else:
+        op.add_column('mits_team', sa.Column('deleted', sa.Boolean(), server_default='False', nullable=False))
+        op.add_column('mits_team', sa.Column('duplicate_of', sideboard.lib.sa.UUID(), nullable=True))
 
 
 def downgrade():

--- a/alembic/versions/735063d71b57_added_document_uploads_and_team_deletion.py
+++ b/alembic/versions/735063d71b57_added_document_uploads_and_team_deletion.py
@@ -1,0 +1,56 @@
+"""Added document uploads and team deletion
+
+Revision ID: 735063d71b57
+Revises: c31b1a94a27d
+Create Date: 2017-11-26 00:16:52.930412
+"""
+
+# revision identifiers, used by Alembic.
+revision = '735063d71b57'
+down_revision = 'c31b1a94a27d'
+branch_labels = None
+depends_on = None
+
+from alembic import op
+import sqlalchemy as sa
+import sideboard.lib.sa
+
+try:
+    is_sqlite = op.get_context().dialect.name == 'sqlite'
+except:
+    is_sqlite = False
+
+if is_sqlite:
+    op.get_context().connection.execute('PRAGMA foreign_keys=ON;')
+    utcnow_server_default = "(datetime('now', 'utc'))"
+else:
+    utcnow_server_default = "timezone('utc', current_timestamp)"
+
+
+def sqlite_column_reflect_listener(inspector, table, column_info):
+    """Adds parenthesis around SQLite datetime defaults for utcnow."""
+    if column_info['default'] == "datetime('now', 'utc')":
+        column_info['default'] = utcnow_server_default
+
+sqlite_reflect_kwargs = {
+    'listeners': [('column_reflect', sqlite_column_reflect_listener)]
+}
+
+
+def upgrade():
+    op.create_table('mits_document',
+    sa.Column('id', sideboard.lib.sa.UUID(), nullable=False),
+    sa.Column('team_id', sideboard.lib.sa.UUID(), nullable=False),
+    sa.Column('filename', sa.Unicode(), server_default='', nullable=False),
+    sa.Column('description', sa.Unicode(), server_default='', nullable=False),
+    sa.ForeignKeyConstraint(['team_id'], ['mits_team.id'], name=op.f('fk_mits_document_team_id_mits_team')),
+    sa.PrimaryKeyConstraint('id', name=op.f('pk_mits_document'))
+    )
+    op.add_column('mits_team', sa.Column('deleted', sa.Boolean(), server_default='False', nullable=False))
+    op.add_column('mits_team', sa.Column('duplicate_of', sideboard.lib.sa.UUID(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('mits_team', 'duplicate_of')
+    op.drop_column('mits_team', 'deleted')
+    op.drop_table('mits_document')

--- a/mits/configspec.ini
+++ b/mits/configspec.ini
@@ -37,6 +37,7 @@ mits_admin = string(default="MITS Admin")
 
 [[mits_app_status]]
 pending = string(default="Pending")
+waitlisted = string(default="Waitlisted")
 declined = string(default="Declined")
 accepted = string(default="Accepted")
 

--- a/mits/model_checks.py
+++ b/mits/model_checks.py
@@ -20,6 +20,9 @@ MITSGame.required = [
 MITSPicture.required = [
     ('description', 'Description')
 ]
+MITSDocument.required = [
+    ('description', 'Description')
+]
 
 
 @validation.MITSTeam

--- a/mits/models.py
+++ b/mits/models.py
@@ -85,8 +85,6 @@ class MITSTeam(MagModel):
     a new one.  In these cases we mark the application as soft-deleted and then
     set the duplicate_of field so that when an applicant tries to log into the
     original application, we can redirect them to the correct application.
-
-    Someone does this.
     """
 
     email_model_name = 'team'

--- a/mits/site_sections/mits_admin.py
+++ b/mits/site_sections/mits_admin.py
@@ -19,6 +19,22 @@ class Root:
             'team': session.mits_team(id)
         }
 
+    def set_status(self, session, id, status=None, confirmed=False, csrf_token=None, return_to='index', message=''):
+        team = session.mits_team(id)
+        matching = [t for t in session.mits_teams() if t.name == team.name and t.id != team.id]
+        if confirmed or (status and not matching and team.status == c.PENDING):
+            check_csrf(csrf_token)
+            team.status = int(status)
+            separator = '&' if '?' in return_to else '?'
+            raise HTTPRedirect(return_to + separator + 'message={}{}{}', team.name, ' marked as ', team.status_label)
+
+        return {
+            'team': team,
+            'message': message,
+            'matching': matching,
+            'return_to': return_to
+        }
+
     def delete_team(self, session, id, duplicate_of=None, csrf_token=None, message=''):
         team = session.mits_team(id)
         if cherrypy.request.method == 'POST':

--- a/mits/site_sections/mits_admin.py
+++ b/mits/site_sections/mits_admin.py
@@ -22,7 +22,7 @@ class Root:
     def set_status(self, session, id, status=None, confirmed=False, csrf_token=None, return_to='index', message=''):
         team = session.mits_team(id)
         matching = [t for t in session.mits_teams() if t.name == team.name and t.id != team.id]
-        if confirmed or (status and not matching and team.status == c.PENDING):
+        if confirmed or (status and not matching and team.status == c.PENDING and team.completion_percentage == 100):
             check_csrf(csrf_token)
             team.status = int(status)
             separator = '&' if '?' in return_to else '?'

--- a/mits/site_sections/mits_admin.py
+++ b/mits/site_sections/mits_admin.py
@@ -9,8 +9,29 @@ class Root:
             'teams': session.mits_teams()
         }
 
+    def create_new_application(self):
+        cherrypy.session.pop('mits_team_id', None)
+        raise HTTPRedirect('../mits_applications/team')
+
     def team(self, session, id, message=''):
         return {
             'message': message,
             'team': session.mits_team(id)
+        }
+
+    def delete_team(self, session, id, duplicate_of=None, csrf_token=None, message=''):
+        team = session.mits_team(id)
+        if cherrypy.request.method == 'POST':
+            check_csrf(csrf_token)
+            team.deleted = True
+            team.duplicate_of = duplicate_of or None
+            raise HTTPRedirect('index?message={}{}{}', team.name, ' marked as deleted',
+                ' and as a duplicate' if duplicate_of else '')
+
+        other = [t for t in session.mits_teams() if t.id != id]
+        return {
+            'team': team,
+            'message': message,
+            'match_count': len([t for t in other if t.name == team.name]),
+            'other_teams': sorted(other, key=lambda t: (t.name != team.name, t.name))
         }

--- a/mits/site_sections/mits_applications.py
+++ b/mits/site_sections/mits_applications.py
@@ -54,7 +54,7 @@ class Root:
     def applicant(self, session, message='', **params):
         applicant = session.mits_applicant(params, applicant=True)
         if applicant.attendee_id:
-            raise HTTPRedirect('../registration/form?id={}&message={}', applicant.attendee_id)
+            raise HTTPRedirect('../preregistration/confirm?id={}&return_to={}', applicant.attendee_id, '../mits_applications/')
 
         if cherrypy.request.method == 'POST':
             message = check(applicant)

--- a/mits/site_sections/mits_applications.py
+++ b/mits/site_sections/mits_applications.py
@@ -13,9 +13,8 @@ class Root:
         cherrypy.session.pop('mits_team_id', None)
         raise HTTPRedirect('team')
 
-    def continue_app(self, id):
-        cherrypy.session['mits_team_id'] = id
-        raise HTTPRedirect('index')
+    def continue_app(self, session, id):
+        session.log_in_as_mits_team(id, redirect_to='index')
 
     def login_explanation(self, message=''):
         return {'message': message}

--- a/mits/templates/mits_admin/badges.html
+++ b/mits/templates/mits_admin/badges.html
@@ -1,0 +1,79 @@
+{% extends "base.html" %}{% set admin_area=True %}
+{% block title %}Panelist Badges{% endblock %}}
+{% block content %}
+
+<script>
+    var hideRow = function (applicantId) {
+        $('#' + applicantId).hide('slow');
+    };
+    var setCompCount = function (teamId, newCount) {
+        $('.' + teamId).text(newCount);
+    };
+    var link = function (teamId, applicantId, attendeeId) {
+        $.post('link_badge', {csrf_token: csrf_token, applicant_id: applicantId, attendee_id: attendeeId}, function (response) {
+            if (response.error) {
+                toastr.error(response.error);
+            } else {
+                toastr.info('Linked applicant to ' + response.name);
+                hideRow(applicantId);
+                setCompCount(teamId, response.comp_count);
+            }
+        }, 'json');
+    };
+    var create = function (teamId, applicantId) {
+        $.post('create_badge', {csrf_token: csrf_token, applicant_id: applicantId}, function (response) {
+            if (response.error) {
+                toastr.error(response.error);
+            } else {
+                toastr.info('Added new attendee badge for applicant');
+                hideRow(applicantId);
+                setCompCount(teamId, response.comp_count);
+            }
+        }, 'json');
+    };
+</script>
+
+<h3>Applicants needing badges</h3>
+
+The following is a list of applicants from accepted teams which are NOT marked as having a badge.  You may use the
+forms below to add badges for those without them OR associate these applicants with existing attendee records.
+
+<table class="table table-striped">
+<thead>
+    <tr>
+        <th>Team</th>
+        <th>Comped Badges</th>
+        <th>Applicant Name</th>
+        <th>Applicant Email</th>
+        <th>Possible Matches</th>
+        <th></th>
+    </tr>
+</thead>
+<tbody>
+{% for a, matches in applicants %}
+    <tr id="{{ a.id }}">
+        <td><a href="team?id={{ a.team_id }}">{{ a.team.name }}</a></td>
+        <td class="{{ a.team_id }}">{{ a.team.comped_badge_count }}</td>
+        <td>{{ a.full_name }}</td>
+        <td>{{ a.email|email_to_link }}</td>
+        <td>
+            {% for attendee in matches %}
+                <p>
+                    <button onClick="link('{{ a.team_id }}', '{{ a.id }}', '{{ attendee.id }}')">Link</button>
+                    {{ attendee|form_link }} [{{ attendee.badge }}] ({{ attendee.email }})
+                </p>
+            {% else %}
+                (no matching attendees)
+            {% endfor %}
+        </td>
+        <td><button onClick="create('{{ a.team_id }}', '{{ a.id }}')">Add Comped Badge</button></td>
+    </tr>
+{% else %}
+    <tr>
+        <td colspan="5"><i>No un-associated applicants</td>
+    </tr>
+{% endfor %}
+</tbody>
+</table>
+
+{% endblock %}

--- a/mits/templates/mits_admin/delete_team.html
+++ b/mits/templates/mits_admin/delete_team.html
@@ -1,0 +1,73 @@
+{% extends "mits_base.html" %}
+{% block body %}
+
+<h2>Delete {{ team.name }}</h2>
+
+This will delete this team's application.  The most common reason for this is when a team fills out the form
+multiple times.  In that case you should select which of the other applications this is a duplicate of, since
+then when someone tries to log into that application we can automatically redirect them to the correct application.
+
+<br/> <br/>
+
+{% if matching_teams %}
+    We have <b>{{ match_count }} other non-deleted application{{ match_count|pluralize }}<b>
+    with the same name as this one (<i>{{ team.name }}</i>), so you should probably select one of those.
+{% else %}
+    There are no other non-deleted applications with the same name as this one.  Therefore you probably want to
+    just mark this as deleted without selecting one of those applications as a duplicate.
+{% endif %}
+
+<br/> <br/>
+
+If applicable, select the duplicate team from the following list:
+
+<br/> <br/>
+
+<form method="post" action="delete_team">
+    {{ csrf_token() }}
+    <input type="hidden" name="id" value="{{ team.id }}" />
+    <table style="width:100%">
+        <thead><tr>
+            <th></th>
+            <th>Name</th>
+            <th>Status</th>
+            <th>Applicants</th>
+            <th>Games</th>
+            <th></th>
+        </tr></thead>
+        <tbody>
+            <tr>
+                <td><input type="radio" name="duplicate_of" value="" {% if not match_count %}checked{% endif %} /></td>
+                <td colspan="4"><i>Delete this application without marking it as a duplicate of anything.</i></td>
+                <td><button>Delete</button></td>
+            </tr>
+            {% for t in other_teams %}
+                <tr>
+                    <td>
+                        <input type="radio" name="duplicate_of" value="{{ t.id }}"
+                            {% if match_count and loop.index == 0 %}checked{% endif %} />
+                    </td>
+                    <td><a href="../mits_applications/continue_app?id={{ t.id }}">{{ t.name }}</a></td>
+                    <td>[{{ t.status_label }}]</td>
+                    <td>
+                        <ul>
+                        {% for applicant in t.applicants %}
+                            <li>{{ applicant.full_name }}</li>
+                        {% endfor %}
+                        </ul>
+                    </td>
+                    <td>
+                        <ul>
+                        {% for game in t.games %}
+                            <li>{{ game.name }}</li>
+                        {% endfor %}
+                        </ul>
+                    </td>
+                    <td><button>Delete</button></td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</form>
+
+{% endblock %}

--- a/mits/templates/mits_admin/delete_team.html
+++ b/mits/templates/mits_admin/delete_team.html
@@ -31,6 +31,7 @@ If applicable, select the duplicate team from the following list:
             <th></th>
             <th>Name</th>
             <th>Status</th>
+            <th>Completion</th>
             <th>Applicants</th>
             <th>Games</th>
             <th></th>
@@ -38,7 +39,7 @@ If applicable, select the duplicate team from the following list:
         <tbody>
             <tr>
                 <td><input type="radio" name="duplicate_of" value="" {% if not match_count %}checked{% endif %} /></td>
-                <td colspan="4"><i>Delete this application without marking it as a duplicate of anything.</i></td>
+                <td colspan="5"><i>Delete this application without marking it as a duplicate of anything.</i></td>
                 <td><button>Delete</button></td>
             </tr>
             {% for t in other_teams %}
@@ -49,6 +50,7 @@ If applicable, select the duplicate team from the following list:
                     </td>
                     <td><a href="../mits_applications/continue_app?id={{ t.id }}">{{ t.name }}</a></td>
                     <td>[{{ t.status_label }}]</td>
+                    <td>{{ t.completion_percentage }}%</td>
                     <td>
                         <ul>
                         {% for applicant in t.applicants %}
@@ -60,6 +62,8 @@ If applicable, select the duplicate team from the following list:
                         <ul>
                         {% for game in t.games %}
                             <li>{{ game.name }}</li>
+                        {% else %}
+                            <i>No games listed</i>
                         {% endfor %}
                         </ul>
                     </td>

--- a/mits/templates/mits_admin/index.html
+++ b/mits/templates/mits_admin/index.html
@@ -23,7 +23,21 @@
         <td>{{ team.primary_contacts[0].full_name }}</td>
         <td>{{ team.applied_local|datetime("%Y-%m-%d") }}</td>
         <td>{{ team.completion_percentage }}%</td>
-        <td>{{ team.status_label }}</td>
+        <td>
+            {% if team.status == c.PENDING %}
+                <form method="post" action="set_status">
+                    {{ csrf_token() }}
+                    <input type="hidden" name="id" value="{{ team.id }}" />
+                    <select name="status">
+                        {{ options(c.MITS_APP_STATUS_OPTS, team.status) }}
+                    </select>
+                    <button>Save</button>
+                </form>
+            {% else %}
+                {{ team.status_label }}
+                [<a href="set_status?id={{ team.id }}">Change</a>]
+            {% endif %}
+        </td>
     </tr>
 {% endfor %}
 </tbody>

--- a/mits/templates/mits_admin/index.html
+++ b/mits/templates/mits_admin/index.html
@@ -3,7 +3,7 @@
 
 <h2>
     MITS Applications
-    <a href="../mits_applications/" class="btn btn-primary pull-right">Create Application</a>
+    <a href="create_new_application" class="btn btn-primary pull-right">Create Application</a>
 </h2>
 
 <table class="table datatable" data-page-length="-1">

--- a/mits/templates/mits_admin/set_status.html
+++ b/mits/templates/mits_admin/set_status.html
@@ -27,6 +27,13 @@
     </div>
 {% endif %}
 
+{% if team.completion_percentage < 100 %}
+    <div class="warning">
+        <b>WARNING:</b> This application is only {{ team.completion_percentage }}% complete.  You may still edit
+        its acceptance status, but you should only do so if you're sure that this is correct.
+    </div>
+{% endif %}
+
 <form method="post" action="set_status">
     {{ csrf_token() }}
     <input type="hidden" name="confirmed" value="true" />

--- a/mits/templates/mits_admin/set_status.html
+++ b/mits/templates/mits_admin/set_status.html
@@ -1,0 +1,42 @@
+{% extends "mits_base.html" %}
+{% block body %}
+
+<h2>Set Status of {{ team.name }}</h2>
+
+{% if team.status != c.PENDING %}
+    <div class="warning">
+        <b>WARNING:</b> This application has already been marked as <b>{{ team.status_label }}</b>.  You should only fill
+        out this form if you really intend to change the already-marked status of this application.
+    </div>
+{% endif %}
+
+{% if matching %}
+    <div class="warning">
+        <b>WARNING:</b> We also have {{ matching|length }} other application{{ matching|length|pluralize }} with the same
+        name ({{ team.name }}):
+        <ul>
+        {% for t in matching %}
+            <li>
+                <a href="form?id={{ t.id }}">
+                    [{{ t.status_label }}] with {{ t.applicants|length }} applicants and {{ t.games|length }} games
+                </a>
+            </li>
+        {% endfor %}
+        </ul>
+        You should probably delete all but one of these similarly-named applications before continuing.
+    </div>
+{% endif %}
+
+<form method="post" action="set_status">
+    {{ csrf_token() }}
+    <input type="hidden" name="confirmed" value="true" />
+    <input type="hidden" name="id" value="{{ team.id }}" />
+    <input type="hidden" name="return_to" value="{{ return_to }}" />
+
+    <select name="status">
+        {{ options(c.MITS_APP_STATUS_OPTS, team.status) }}
+    </select>
+    <button>Set Status</button>
+</form>
+
+{% endblock %}

--- a/mits/templates/mits_admin/team.html
+++ b/mits/templates/mits_admin/team.html
@@ -15,6 +15,7 @@
             {% if team.status == c.PENDING %}
                 (application is {{ team.completion_percentage }}% complete)
             {% endif %}
+            <br/> <a href="set_status?id={{ team.id }}&return_to=form%3f{{ team.id }}">Change Status</a>
         </div>
     </div>
     <div class="form-group">

--- a/mits/templates/mits_admin/team.html
+++ b/mits/templates/mits_admin/team.html
@@ -38,7 +38,13 @@
     {% for a in team.applicants|sort(attribute='full_name') %}
         <tr>
             <td><ul><li></li></ul></td>
-            <td>{{ a.full_name }}</td>
+            <td>
+                {% if a.attendee_id %}
+                    {{ a.attendee|form_link }}
+                {% else %}
+                    {{ a.full_name }}
+                {% endif %}
+            </td>
             <td>{{ a.email }}</td>
             <td>{{ a.cellphone }}</td>
             <td>

--- a/mits/templates/mits_admin/team.html
+++ b/mits/templates/mits_admin/team.html
@@ -97,6 +97,15 @@
         <li><a target="_blank" href="{{ picture.url }}" title="{{ picture.description }}">{{ picture.filename }}</a></li>
     {% endfor %}
     </ul>
+
+    {% if team.documents %}
+        <h3>Documents</h3>
+        <ul>
+        {% for doc in team.documents|sort(attribute='filename') %}
+            <li><a href="{{ doc.url }}" title="{{ doc.description }}">{{ doc.filename }}</a></li>
+        {% endfor %}
+        </ul>
+    {% endif %}
 </div>
 
 <div class="text-center">

--- a/mits/templates/mits_admin/team.html
+++ b/mits/templates/mits_admin/team.html
@@ -1,8 +1,9 @@
 {% extends "mits_base.html" %}
 {% block body %}
 
-<h2>
+<h2 class="btn-toolbar">
     {{ team.name }}
+    <a href="delete_team?id={{ team.id }}" class="btn btn-danger pull-right">Delete Application</a>
     <a href="../mits_applications/continue_app?id={{ team.id }}" class="btn btn-primary pull-right">Edit Application</a>
 </h2>
 

--- a/mits/templates/mits_applications/document.html
+++ b/mits/templates/mits_applications/document.html
@@ -1,0 +1,33 @@
+{% extends "mits_base.html" %}
+{% block body %}
+
+<h3>Upload a Document</h3>
+
+You may optionally upload documents such as the rulebook for your game, advertisements, endorsements, etc.
+<br/> <br/>
+
+<form method="post" enctype="multipart/form-data" action="document" class="form-horizontal" role="form">
+    {{ csrf_token() }}
+
+    <div class="form-group">
+        <label class="col-sm-3 control-label">Description of Document</label>
+        <div class="col-sm-6">
+            <textarea class="form-control" name="description" rows="4">{{ doc.description }}</textarea>
+        </div>
+    </div>
+
+    <div class="form-group">
+        <label class="col-sm-3 control-label">Upload</label>
+        <div class="col-sm-6">
+            <input type="file" name="upload" />
+        </div>
+    </div>
+
+    <div class="form-group">
+        <div class="col-sm-6 col-sm-offset-3">
+            <button type="submit" class="btn btn-primary">Upload Document</button>
+        </div>
+    </div>
+</form>
+
+{% endblock %}

--- a/mits/templates/mits_applications/index.html
+++ b/mits/templates/mits_applications/index.html
@@ -106,8 +106,29 @@ This is your application for the MAGFest Indie Tabletop Showcase for your produc
         </tr>
     {% endfor %}
     </table>
-
     <a href="picture?id=None">Add a Picture</a>
+
+    <br/> <br/>
+    While you are <b>required</b> to upload at least one picture of your game, you may also optionally upload
+    other documents such as rulebooks to assist our judges.  We can even include links to these documents on our
+    website to help promote your game if you specifically request that we do so.
+
+    <table>
+    {% for doc in team.documents|sort(attribute='filename') %}
+        <tr>
+            <td><ul><li></li></ul></td>
+            <td><a target="_blank" href="{{ doc.url }}" title="{{ doc.description }}">{{ doc.filename }}</a></td>
+            <td>
+                <form method="post" action="delete_document">
+                    {{ csrf_token() }}
+                    <input type="hidden" name="id" value="{{ doc.id }}" />
+                    <input type="submit" value="Delete" />
+                </form>
+            </td>
+        </tr>
+    {% endfor %}
+    </table>
+    <a href="document?id=None">Add a Document</a>
 {% endif %}
 
 

--- a/mits/templates/mits_applications/index.html
+++ b/mits/templates/mits_applications/index.html
@@ -60,7 +60,7 @@ This is your application for the MAGFest Indie Tabletop Showcase for your produc
     </tr>
 {% endfor %}
 </table>
-{% if team.applicants|length < c.MITS_BADGES_PER_TEAM %}
+{% if team.can_add_badges %}
     <a href="applicant?id=None">Add a Team Member</a>
 {% endif %}
 


### PR DESCRIPTION
I ended up having a lot less time for coding over this Thanksgiving break than usual, but I did manage to get the following MITS features implemented:

1) Applications can be soft-deleted.  We had a bunch of people fill out the same application multiple times, so I added the ability to not only soft-delete such applications, but mark deleted applications as duplicates of another app, so that we can automatically redirect to the correct application if someone tries to log into the deleted one.

2) Applications can actually be marked as accepted/waitlisted/declined.

3) Documents can be uploaded now in addition to pictures, since we wanted people to be able to upload rulebooks for their games and such.

4) Admins can now associate applicants with attendees, either by linking them to existing Attendee records or by creating a new Attendee record and linking that to the applicant.

I also made a few miscellaneous bugfixes, which I'll point out inline.