### PR TITLE
New automated emails and CSV export

### DIFF
--- a/mits/automated_emails.py
+++ b/mits/automated_emails.py
@@ -31,6 +31,14 @@ MITSEmail('Thanks for submitting your MITS application!', 'mits_submitted.txt',
           lambda team: team.submitted,
           ident='mits_application_submitted')
 
+MITSEmail('Please fill out the remainder of your MITS application', 'mits_preaccepted.txt',
+          lambda team: team.accepted and team.completion_percentage < 100,
+          ident='mits_preaccepted_incomplete')
+
+MITSEmail('MITS initial panel information', 'mits_initial_panel_info.txt',
+          lambda team: team.accepted and team.panel_interest,
+          ident='mits_initial_panel_info')
+
 # TODO: emails we still need to configure include but are not limited to:
 # -> when teams have been accepted
 # -> when teams have been declined

--- a/mits/models.py
+++ b/mits/models.py
@@ -117,7 +117,9 @@ class MITSTeam(MagModel):
 
     @property
     def can_save(self):
-        return c.HAS_MITS_ADMIN_ACCESS or (self.is_new and c.BEFORE_MITS_SUBMISSION_DEADLINE or c.BEFORE_MITS_EDITING_DEADLINE)
+        return (c.HAS_MITS_ADMIN_ACCESS
+            or self.status in [c.ACCEPTED, c.WAITLISTED]
+            or (self.is_new and c.BEFORE_MITS_SUBMISSION_DEADLINE or c.BEFORE_MITS_EDITING_DEADLINE))
 
     @property
     def completed_hotel_form(self):

--- a/mits/site_sections/mits_admin.py
+++ b/mits/site_sections/mits_admin.py
@@ -129,3 +129,19 @@ class Root:
                 '1 table' if val in available else ''
                 for val, desc in c.MITS_SCHEDULE_OPTS
             ])
+
+    @csv_file
+    def panel_requests(self, out, session):
+        out.writerow(['URL', 'Team', 'Primary Contact Names', 'Primary Contact Emails']
+                   + [desc for val, desc in c.MITS_SCHEDULE_OPTS])
+        for team in session.mits_teams().filter_by(status=c.ACCEPTED, panel_interest=True):
+            available = getattr(team.schedule, 'availability_ints', [])
+            out.writerow([
+                c.URL_BASE + '/mits_admin/team?id=' + team.id,
+                team.name,
+                '\n'.join(a.full_name for a in team.primary_contacts),
+                '\n'.join(a.email for a in team.primary_contacts)
+            ] + [
+                'available' if val in available else ''
+                for val, desc in c.MITS_SCHEDULE_OPTS
+            ])

--- a/mits/site_sections/mits_admin.py
+++ b/mits/site_sections/mits_admin.py
@@ -102,3 +102,30 @@ class Root:
             return {'error': 'Unexpected error: unable to add attendee'}
         else:
             return {'comp_count': applicant.team.comped_badge_count}
+
+    @csv_file
+    def hotel_requests(self, out, session):
+        for team in session.mits_teams().filter_by(status=c.ACCEPTED):
+            for applicant in team.applicants:
+                if applicant.requested_room_nights:
+                    out.writerow([
+                        team.name,
+                        applicant.full_name,
+                        applicant.email,
+                        applicant.cellphone
+                    ] + [
+                        desc if val in applicant.requested_room_nights_ints else ''
+                        for val, desc in c.MITS_ROOM_NIGHT_OPTS
+                    ])
+
+    @csv_file
+    def schedule_requests(self, out, session):
+        out.writerow([''] + [desc for val, desc in c.MITS_SCHEDULE_OPTS])
+        for team in session.mits_teams().filter_by(status=c.ACCEPTED):
+            available = getattr(team.schedule, 'availability_ints', [])
+            multiple = getattr(team.schedule, 'multiple_tables_ints', [])
+            out.writerow([team.name] + [
+                'multiple' if val in multiple else
+                '1 table' if val in available else ''
+                for val, desc in c.MITS_SCHEDULE_OPTS
+            ])

--- a/mits/site_sections/mits_applications.py
+++ b/mits/site_sections/mits_applications.py
@@ -193,10 +193,18 @@ class Root:
         }
 
     def submit_for_judging(self, session):
+        """
+        Sometimes we mark partially completed applications as accepted, either
+        because there's enough information to complete judging OR because an
+        admin created the application manually after the deadline for a team
+        they wanted to make an exception for.  Applicants are therefore allowed
+        to submit their applications either before the deadline or at any time
+        if they've been pre-accepted.
+        """
         team = session.logged_in_mits_team()
         if team.steps_completed < c.MITS_APPLICATION_STEPS - 1:
             raise HTTPRedirect('index?message={}', 'You have not completed all of the required steps')
-        elif c.AFTER_MITS_SUBMISSION_DEADLINE:
+        elif c.AFTER_MITS_SUBMISSION_DEADLINE and not team.accepted:
             raise HTTPRedirect('index?message={}', 'You cannot submit an application past the deadline')
         else:
             team.submitted = datetime.now(UTC)

--- a/mits/templates/emails/mits_initial_panel_info.txt
+++ b/mits/templates/emails/mits_initial_panel_info.txt
@@ -1,0 +1,11 @@
+{{ team.salutation }},
+
+You're receiving this email because your team ({{ team.name }}) was accepted to the MAGFest Indie Tabletop Showcase and you expressed interest in reserving a timeslot to host a tabletop-related panel.
+
+Panels have begun scheduling everyone's timeslots, and you will be allotted a 1 hour tabletop panel at some point during MAGFest during one of the times you indicated on your application that you were available to present.  We'll let you know your exact timeslot as soon as the schedule is finalized.
+
+If you have any panel-related questions in the meantime, or if you would like to decline this panel, please email panels@magfest.org
+
+If you have any non-panel MITS-related questions, you can always send those to mits@magfest.org
+
+{{ c.MITS_EMAIL_SIGNATURE }}

--- a/mits/templates/emails/mits_preaccepted.txt
+++ b/mits/templates/emails/mits_preaccepted.txt
@@ -1,0 +1,9 @@
+{{ team.salutation }},
+
+Thanks again for signing up for the MAGFest Indie Tabletop Showcase.  As we've previously discussed, your application has been pre-accepted, but we still need you to fill out the remainder of the information about your team, since your application is currently only {{ team.completion_percentage }}% complete.
+
+You can finish providing us the remaining info at {{ c.URL_BASE }}/mits_applications/continue_app?id={{ team.id }}
+
+In the meantime, please let us know if you have any questions!
+
+{{ c.MITS_EMAIL_SIGNATURE }}


### PR DESCRIPTION
This PR contains three things:

1) A new CSV export for accepted teams who are interested in presenting a panel.

2) Two new automated emails, one for panels and one for people who were pre-accepted without having filled out their entire application.

3) Because we added some applications after the deadline, we want pre-accepted applications to be able to complete their submission by filling out all parts of the form to get to 100%.